### PR TITLE
Quick fix for multi-system route clipboard copy

### DIFF
--- a/src/Notifications/RouteProgressAnnouncer.cpp
+++ b/src/Notifications/RouteProgressAnnouncer.cpp
@@ -54,6 +54,7 @@ void RouteProgressAnnouncer::handleEventSystemOnly(const JFile *journal, Event *
                 auto system = route[i][0];
                 if(system != route[arrivedAt][0]) {
                     nextSystem = system;
+					break;
                 }
             }
 


### PR DESCRIPTION
This is a fix for routes >2 systems always choosing the last system in the list to copy to the clipboard.  Note that any events which focus the current system in the list will still overwrite the clipboard with the current system.